### PR TITLE
Fix boilerplate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
-all: compile
-
-Makefile.coq:
-	coq_makefile -f _CoqProject -o Makefile.coq
-
-compile: Makefile.coq
-	make -f Makefile.coq
-
-install: Makefile.coq
-	make -f Makefile.coq install
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
 
 clean: Makefile.coq
-	make -f Makefile.coq clean
-	rm -f Makefile.coq Makefile.coq.conf
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
+
+Makefile.coq: _CoqProject
+	$(COQBIN)coq_makefile -f _CoqProject -o Makefile.coq
+
+force _CoqProject Makefile: ;
+
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Follow the instructions on https://github.com/coq-community/templates to regener
 
 
 
-Port of agdarsec to Coq
+Port of the agdarsec total parser combinator library to Coq.
 
 ## Meta
 
@@ -35,7 +35,8 @@ Port of agdarsec to Coq
 - Compatible Coq versions: 8.16 or later
 - Additional dependencies: none
 - Coq namespace: `parseque`
-- Related publication(s): none
+- Related publication(s):
+  - [agdarsec - Total Parser Combinators](https://gallais.github.io/pdf/agdarsec18.pdf) 
 
 ## Building and installation instructions
 

--- a/coq-parseque.opam
+++ b/coq-parseque.opam
@@ -12,7 +12,7 @@ license: "MIT"
 
 synopsis: "Total parser combinators in Coq"
 description: """
-Port of agdarsec to Coq"""
+Port of the agdarsec total parser combinator library to Coq."""
 
 build: [make "-j%{jobs}%"]
 install: [make "install"]

--- a/meta.yml
+++ b/meta.yml
@@ -8,7 +8,11 @@ action: true
 synopsis: Total parser combinators in Coq
 
 description: |-
-  Port of agdarsec to Coq
+  Port of the agdarsec total parser combinator library to Coq.
+
+publications:
+- pub_url: https://gallais.github.io/pdf/agdarsec18.pdf
+  pub_title: agdarsec - Total Parser Combinators
 
 authors:
 - name: G. Allais


### PR DESCRIPTION
@womeier the current makefile unfortunately can't use parallel jobs. Not a big deal usually since the build time is so short, but this PR fixes it. I also made the description less cryptic and added a link to the agdarsec paper.