### PR TITLE
Short-circuiting the alt combinator

### DIFF
--- a/src/Category.v
+++ b/src/Category.v
@@ -23,13 +23,13 @@ Arguments MkRawApplicative {_} {_}.
 
 Class RawAlternative (F : Type -> Type) `{RawApplicative F} :=
   MkRawAlternative { _fail : forall A, F A
-                   ; _alt  : forall A, F A -> F A -> F A
+                   ; _alt  : forall A, F A -> (unit -> F A) -> F A
                    }.
 
 Definition fail {F : Type -> Type} `{RawAlternative F} {A : Type} : F A :=
   _fail _.
 
-Definition alt {F : Type -> Type} `{RawAlternative F} {A : Type} : F A -> F A -> F A :=
+Definition alt {F : Type -> Type} `{RawAlternative F} {A : Type} : F A -> (unit -> F A) -> F A :=
   _alt _.
 
 Definition fromOption {F : Type -> Type} `{RawAlternative F} {A : Type} (v : option A) : F A :=
@@ -74,7 +74,7 @@ Instance listRawApplicative : RawApplicative list :=
 
 #[global]
 Instance listRawAlternative : RawAlternative list :=
-  MkRawAlternative (@nil) (fun _ xs ys => xs ++ ys).
+  MkRawAlternative (@nil) (fun _ xs ys => xs ++ (ys tt)).
 
 #[global]
 Instance listRawMonad : RawMonad list :=
@@ -95,7 +95,7 @@ Instance optionRawApplicative : RawApplicative option :=
 
 #[global]
 Instance optionRawAlternative : RawAlternative option :=
-  MkRawAlternative (@None) (fun _ => option_rect _ (fun x _ => Some x) (fun x => x)).
+  MkRawAlternative (@None) (fun _ => option_rect _ (fun x _ => Some x) (fun x => (x tt))).
 
 #[global]
 Instance optionRawMonad : RawMonad option :=

--- a/src/Combinators.v
+++ b/src/Combinators.v
@@ -55,7 +55,7 @@ Definition fail : Parser Toks Tok M A n := MkParser (fun _ _ _ => fail).
 
 Definition alt (p q : Parser Toks Tok M A n) : Parser Toks Tok M A n :=
   MkParser (fun _ mlen toks =>
-  alt (runParser p mlen toks) (runParser q mlen toks)).
+  alt (runParser p mlen toks) (fun _ => runParser q mlen toks)).
 
 Definition alts (ps : list (Parser Toks Tok M A n)) : Parser Toks Tok M A n :=
   List.fold_right alt fail ps.
@@ -66,7 +66,7 @@ Definition andmbind (p : Parser Toks Tok M A n)
   let salen   := Nat.le_trans _ _ _ (small sa) mlen in
   let combine := fun sb => Success.map (fun p => (fst p, Some (snd p))) (Success.and sa sb) in
   Category.alt (fmap combine (runParser (call (q (value sa)) salen) (Nat.le_refl _) (leftovers sa)))
-               (pure (Success.map (fun a => (a , None)) sa)))).
+               (fun _ => pure (Success.map (fun a => (a , None)) sa)))).
 
 (* This could be implemented in terms of andmbind + guardM but for
    efficiency reasons we give a direct implementation *)
@@ -179,7 +179,7 @@ Definition schainl_aux (n : nat) (rec : Box LChain n) : LChain n := fun sa op =>
   pure (lt_lift (small sa) res))).
 
 Definition schainl {n : nat} : LChain n :=
-  Fix LChain (fun n rec sa op => Category.alt (schainl_aux n rec sa op) (pure sa)) n.
+  Fix LChain (fun n rec sa op => Category.alt (schainl_aux n rec sa op) (fun _ => pure sa)) n.
 
 Definition iteratel {n : nat} (val : Parser Toks Tok M A n)
   (op : Box (Parser Toks Tok M (A -> A)) n) : Parser Toks Tok M A n :=


### PR DESCRIPTION
As discussed in #14 . This PR makes the evaluation of the second argument of the alt combinator `<|>` lazy.
Tested with my local build of a downstream application which still works after the update.